### PR TITLE
Format property and floats instead of ints

### DIFF
--- a/UICountingLabel.h
+++ b/UICountingLabel.h
@@ -10,9 +10,11 @@ typedef enum {
 
 @interface UICountingLabel : UILabel
 
--(void)setValue:(int)value;
--(void)setValue:(int)value withCountingMethod:(UILabelCountingMethod)countingMethod;
--(void)setValue:(int)value withCountingMethod:(UILabelCountingMethod)countingMethod andDuration:(NSTimeInterval)duration;
+@property (nonatomic, strong) NSString *format;
+
+-(void)setValue:(float)value;
+-(void)setValue:(float)value withCountingMethod:(UILabelCountingMethod)countingMethod;
+-(void)setValue:(float)value withCountingMethod:(UILabelCountingMethod)countingMethod andDuration:(NSTimeInterval)duration;
 
 @end
 

--- a/UICountingLabel.m
+++ b/UICountingLabel.m
@@ -84,8 +84,8 @@
 
 @interface UICountingLabel ()
 
-@property int startingValue;
-@property int destinationValue;
+@property float startingValue;
+@property float destinationValue;
 @property NSTimeInterval progress;
 @property NSTimeInterval lastUpdate;
 @property NSTimeInterval totalTime;
@@ -97,17 +97,17 @@
 
 @implementation UICountingLabel
 
--(void)setValue:(int)value
+-(void)setValue:(float)value
 {
     [self setValue:value withCountingMethod:UILabelCountingMethodEaseInOut andDuration:2.0f];
 }
 
--(void)setValue:(int)value withCountingMethod:(UILabelCountingMethod)countingMethod
+-(void)setValue:(float)value withCountingMethod:(UILabelCountingMethod)countingMethod
 {
     [self setValue:value withCountingMethod:countingMethod andDuration:2.0f];
 }
 
--(void)setValue:(int)value withCountingMethod:(UILabelCountingMethod)countingMethod andDuration:(NSTimeInterval)duration
+-(void)setValue:(float)value withCountingMethod:(UILabelCountingMethod)countingMethod andDuration:(NSTimeInterval)duration
 {
     
     self.easingRate = 3.0f;
@@ -154,15 +154,18 @@
     
     float percent = self.progress / self.totalTime;
     float updateVal =[self.counter update:percent];
-    int value =  self.startingValue +  (updateVal * (self.destinationValue - self.startingValue));
+    float value =  self.startingValue +  (updateVal * (self.destinationValue - self.startingValue));
     
-    self.text = [NSString stringWithFormat:@"%d",value];
+    
+    
+    self.text = [NSString stringWithFormat:_format,value];
     
 }
 
 -(void)dealloc
 {
     [_counter release];
+    [_format release];
     [super dealloc];
 }
 


### PR DESCRIPTION
I have added a format property which allows the label to display more than just numbers but still count. For example, the label may show:

`5%`

I have changed the label to use floats instead of ints. This works well with the format property, for example a format of `.2f%%` will give the following:

`5.24%`
