### PR TITLE
Fix label not counting while UI Updates happening

### DIFF
--- a/UICountingLabel.m
+++ b/UICountingLabel.m
@@ -137,7 +137,7 @@
     self.counter.rate = 3.0f;
     
     NSTimer* timer = [NSTimer timerWithTimeInterval:(1.0f/30.0f) target:self selector:@selector(updateValue:) userInfo:nil repeats:YES];
-    [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSDefaultRunLoopMode];
+    [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
 }
 
 -(void)updateValue:(NSTimer*)timer


### PR DESCRIPTION
NSTimers don't fire when user interface updates are happening, so the label will appear to skip numbers when embedded in something like a scroll view that's scrolling.
This changes from NSDefaultRunLoopMode to NSRunLoopCommonModes, which includes events coming in from the UI during scrolling, allowing the timer to continue to animate.
