### PR TITLE
Handle 0s durations

### DIFF
--- a/UICountingLabel.m
+++ b/UICountingLabel.m
@@ -107,6 +107,12 @@
 
 -(void)countFrom:(float)startValue to:(float)endValue withDuration:(NSTimeInterval)duration
 {
+    if(duration == 0.0){
+        // No animation
+        [self setTextValue:endValue];
+        [self runCompletionBlock];
+        return;
+    }
     
     self.easingRate = 3.0f;
     self.startingValue = startValue;
@@ -158,6 +164,16 @@
     float value =  self.startingValue +  (updateVal * (self.destinationValue - self.startingValue));
     
     
+    [self setTextValue:value];
+    
+    if(self.progress == self.totalTime)
+    {
+        [self runCompletionBlock];
+    }
+}
+
+- (void)setTextValue:(float)value
+{
     if(self.formatBlock != nil)
     {
         self.text = self.formatBlock(value);
@@ -174,8 +190,11 @@
             self.text = [NSString stringWithFormat:self.format,value];
         }
     }
+}
 
-	if(self.progress == self.totalTime && self.completionBlock != nil)
+- (void)runCompletionBlock
+{
+	if(self.completionBlock != nil)
 	{
 		self.completionBlock();
 		self.completionBlock = nil;


### PR DESCRIPTION
If you call `countFrom:` with a duration of `0` the label's value is mangled – [along the way](https://github.com/dataxpress/UICountingLabel/blob/26bfd48b39a3e972e61df0730a017c738828cfd9/UICountingLabel.m#L156) a divide-by-zero happens that seems to find its way in.

It should _probably_ be the caller's problem to make sure they aren't sending `0`, but this way they won't have to worry!
