### PR TITLE
tvOS support

### DIFF
--- a/UICountingLabel.podspec
+++ b/UICountingLabel.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Tim Gostony" => "dataxpress@gmail.com" }
   s.source       = { :git => "https://github.com/dataxpress/UICountingLabel.git", :tag => s.version.to_s }
   s.ios.deployment_target = '5.0'
+  s.tvos.deployment_target = '9.0'
   s.source_files = 'UICountingLabel.{h,m}'
   s.exclude_files = 'Classes/Exclude'
   s.requires_arc = true

--- a/UICountingLabel.podspec
+++ b/UICountingLabel.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Tim Gostony" => "dataxpress@gmail.com" }
   s.source       = { :git => "https://github.com/dataxpress/UICountingLabel.git", :tag => s.version.to_s }
-  s.platform     = :ios, '5.0'
+  s.ios.deployment_target = '5.0'
   s.source_files = 'UICountingLabel.{h,m}'
   s.exclude_files = 'Classes/Exclude'
   s.requires_arc = true


### PR DESCRIPTION
I was able to use UICountingLabels in a Swift project with tvOS target.

Add to `Podfile`

```
pod 'UICountingLabel'
```

I created a .m file in my project:

`
(Right-click) -> New File... -> Objective-C File (.m) -> 'new bridging header?' -> YES
`

In the new `UIKitCatalog-Bridging-Header.h` file, add

```
#import "Pods/UICountingLabel/UICountingLabel.h"
```

Add a UICountingLabel outlet to your view controller

```
    @IBOutlet weak var timerLabel: UICountingLabel!
```

It should work properly!

