### PR TITLE
Expose `-setTextValue:` for subclasses

### DIFF
--- a/UICountingLabel.h
+++ b/UICountingLabel.h
@@ -34,3 +34,10 @@ typedef NSAttributedString* (^UICountingLabelAttributedFormatBlock)(CGFloat valu
 
 @end
 
+
+// For use by subclasses.
+@interface UICountingLabel (Protected)
+
+- (void)setTextValue:(float)value;
+
+@end

--- a/UICountingLabel.h
+++ b/UICountingLabel.h
@@ -38,6 +38,6 @@ typedef NSAttributedString* (^UICountingLabelAttributedFormatBlock)(CGFloat valu
 // For use by subclasses.
 @interface UICountingLabel (Protected)
 
-- (void)setTextValue:(float)value;
+- (void)setTextValue:(CGFloat)value;
 
 @end


### PR DESCRIPTION
This exposes the `-setTextValue:` method for the purpose of subclassing.

I had a case where the value to animate wasn't a simple value. It was a "months" count, but once you hit 12 months it had to flip over to years and months, so:

- 10 months
- 11 months
- 1 year
- 1 year 1 month
- 1 year 2 months
- etc

`UICountingLabel` provides an excellent framework for making things go, especially the animation curves -- I just needed to easily set the text value. I can pass in the total count of months, I just need to then format the text differently. So subclassing works, but I needed `-setTextValue:` to be exposed in the header so I could override it.

I opted to just make the category in the main .h file because it avoided the need to modify the podspec. Often people approach this by having something like a `UICountingLabel_Subclasses.h` type of file that then exposes those things. Same issue in the end, but a little clearer and if someone wants to subclass they do need to explicitly #import the right file -- tho perhaps less critical now given I'm using Cocoapods, Swift, and thus frameworks/modules.

If there's another approach you'd like to take to support this, I'm open to alternatives that work better for the distribution.

Thank you.
