### PR TITLE
Updated to iOS 7.0 min deployment target

### DIFF
--- a/CountingTestProject.xcodeproj/project.pbxproj
+++ b/CountingTestProject.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CountingTestProject/CountingTestProject-Prefix.pch";
 				INFOPLIST_FILE = "CountingTestProject/CountingTestProject-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.timgostony.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -289,6 +290,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CountingTestProject/CountingTestProject-Prefix.pch";
 				INFOPLIST_FILE = "CountingTestProject/CountingTestProject-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.timgostony.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;

--- a/UICountingLabel.h
+++ b/UICountingLabel.h
@@ -19,7 +19,7 @@ typedef NSAttributedString* (^UICountingLabelAttributedFormatBlock)(CGFloat valu
 
 @property (nonatomic, copy) UICountingLabelFormatBlock formatBlock;
 @property (nonatomic, copy) UICountingLabelAttributedFormatBlock attributedFormatBlock;
-@property (nonatomic, copy) void (^completionBlock)();
+@property (nonatomic, copy) void (^completionBlock)(void);
 
 -(void)countFrom:(CGFloat)startValue to:(CGFloat)endValue;
 -(void)countFrom:(CGFloat)startValue to:(CGFloat)endValue withDuration:(NSTimeInterval)duration;

--- a/UICountingLabel.podspec
+++ b/UICountingLabel.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "UICountingLabel"
-  s.version      = "1.4.0"
+  s.version      = "1.4.1"
   s.summary      = "Adds animated counting support to UILabel."
   s.homepage     = "https://github.com/dataxpress/UICountingLabel"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Tim Gostony" => "dataxpress@gmail.com" }
   s.source       = { :git => "https://github.com/dataxpress/UICountingLabel.git", :tag => s.version.to_s }
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
   s.source_files = 'UICountingLabel.{h,m}'
   s.exclude_files = 'Classes/Exclude'


### PR DESCRIPTION
fix: removing a warning in a block declaration
feat: updated deployment target to iOS 7.0 (minimum to build without errors with Xcode 9)
feat: updated podspec's deployment target to iOS 7.0 (as Xcode's project)

When using this pod with a minimum target of iOS 10.0 and Xcode 9, the pod has 2 warnings, one about the block declaration not being a prototype.
The other one about `setAttributedText:` which is only available in iOS 6.0 or newer.