### PR TITLE
Update UICountingLabel.m: fix crash

### DIFF
--- a/UICountingLabel.m
+++ b/UICountingLabel.m
@@ -109,6 +109,9 @@
     [self.timer invalidate];
     self.timer = nil;
     
+    if(self.format == nil) {
+        self.format = @"%f";
+    }
     if (duration == 0.0) {
         // No animation
         [self setTextValue:endValue];
@@ -120,9 +123,6 @@
     self.progress = 0;
     self.totalTime = duration;
     self.lastUpdate = [NSDate timeIntervalSinceReferenceDate];
-
-    if(self.format == nil)
-        self.format = @"%f";
 
     switch(self.method)
     {


### PR DESCRIPTION
If user not set value for `format` and set `startValue` 、`endValue`  、 `duration` all to 0,  it will crash when call `[self setTextValue:endValue]` . It's because the format is nil when use`[NSString stringWithFormat:self.format,(int)value]`