### PR TITLE
Replacing Wall Clock with Monotonic Clock

### DIFF
--- a/UICountingLabel/Classes/UICountingLabel.m
+++ b/UICountingLabel/Classes/UICountingLabel.m
@@ -174,7 +174,7 @@
     self.easingRate = 3.0f;
     self.progress = 0;
     self.totalTime = duration;
-    self.lastUpdate = [NSDate timeIntervalSinceReferenceDate];
+    self.lastUpdate = CACurrentMediaTime();
 
     switch(self.method)
     {
@@ -224,7 +224,7 @@
 - (void)updateValue:(NSTimer *)timer {
     
     // update progress
-    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    NSTimeInterval now = CACurrentMediaTime();
     self.progress += now - self.lastUpdate;
     self.lastUpdate = now;
     


### PR DESCRIPTION
Replacing Wall Clock with Monotonic Clock to prevent negative progress when there are leap seconds or timezone changes.

For reference, here are classic solutions for Monotonic (and reliable) time progression:
 - `mach_absolute_time()` from Darwin, but requires conversion to seconds with mach_timebase_info
 - `ProcessInfo.processInfo.systemUptime` from Foundation, open-source wrapper on mach_absolute_time() giving directly a number of seconds
 - `DispatchTime.now()` from Dispatch, open-source wrapper on mach_absolute_time() giving easily a number of seconds
 - `CACurrentMediaTime()` from QuartzCore, close-source wrapper giving directly a number of seconds, and what Apple uses for animations: https://www.google.com/search?q=CACurrentMediaTime+site%3Aopensource.apple.com

And here are classic solutions for Wall clocks (totally *unreliable*! for timing) which are affected by leap seconds, timezone changes, winter/summer hour changes, any manual user change on the system clock:
- `gettimeofday()` in POSIX standard
- `DispatchWallTime.now()` from Dispatch
- `CFAbsoluteTimeGetCurrent()` from CoreFoundation
- `Date()`/`NSDate()` from Foundation and any of its methods (including `timeIntervalSinceReferenceDate`)
