### PR TITLE
following the IEEE printf specification

### DIFF
--- a/UICountingLabel.m
+++ b/UICountingLabel.m
@@ -253,7 +253,8 @@
     else
     {
         // check if counting with ints - cast to int
-        if([self.format rangeOfString:@"%(.*)d" options:NSRegularExpressionSearch].location != NSNotFound || [self.format rangeOfString:@"%(.*)i"].location != NSNotFound )
+        // regex based on IEEE printf specification: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html
+        if([self.format rangeOfString:@"%[^fega]*[diouxc]" options:NSRegularExpressionSearch|NSCaseInsensitiveSearch].location != NSNotFound)
         {
             self.text = [NSString stringWithFormat:self.format,(int)value];
         }


### PR DESCRIPTION
1. previously, the case of %i wasn't working because `options:NSRegularExpressionSearch` was missing for the second part of the expression.
2. there are actually more integer specifiers than just `d` and `i`, there are also `o`, `u`, `x` and `c` and their uppercase counterparts.
3. `(.*)` was too greedy as it would capture float specifiers, so if the format was `%f dogecoins` it would have a match. This is solved by excluding the float specifiers `f`, `e`, `g`, `a` and their uppercase counterparts.

More info in my Stack Overflow answer: https://stackoverflow.com/questions/52332747/what-are-the-supported-swift-string-format-specifiers